### PR TITLE
Reintroduce CodeEditor in the main screen.

### DIFF
--- a/src/portrait_ui/editor_scene.tscn
+++ b/src/portrait_ui/editor_scene.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=5 format=3 uid="uid://bihwwoedqcyo8"]
+[gd_scene load_steps=6 format=3 uid="uid://bihwwoedqcyo8"]
 
 [ext_resource type="Script" uid="uid://dunoppeuubgd1" path="res://src/portrait_ui/editor_scene.gd" id="1_o7lif"]
 [ext_resource type="PackedScene" uid="uid://cr1fdlmbknnko" path="res://src/ui_parts/code_editor.tscn" id="3_4uluy"]
 [ext_resource type="PackedScene" uid="uid://ccynisiuyn5qn" path="res://src/ui_parts/inspector.tscn" id="4_jik7v"]
 [ext_resource type="PackedScene" uid="uid://bvrncl7e6yn5b" path="res://src/ui_parts/display.tscn" id="5_gb5yr"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mt61i"]
+bg_color = Color(0.0745098, 0.0745098, 0.121569, 0.501961)
 
 [node name="MainScene" type="VBoxContainer"]
 anchors_preset = 15
@@ -11,6 +14,7 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+theme_override_constants/separation = 0
 script = ExtResource("1_o7lif")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
@@ -24,13 +28,23 @@ layout_mode = 2
 size_flags_horizontal = 3
 theme_override_constants/separation = 40
 theme_override_constants/minimum_grab_thickness = 30
+theme_override_styles/split_bar_background = SubResource("StyleBoxFlat_mt61i")
 
-[node name="Inspector" parent="PanelContainer/HSplitContainer" instance=ExtResource("4_jik7v")]
+[node name="TabContainer" type="TabContainer" parent="PanelContainer/HSplitContainer"]
 layout_mode = 2
+size_flags_vertical = 3
+tab_alignment = 1
+current_tab = 0
+tabs_position = 1
 
-[node name="CodeEditor" parent="PanelContainer/HSplitContainer" instance=ExtResource("3_4uluy")]
+[node name="Inspector" parent="PanelContainer/HSplitContainer/TabContainer" instance=ExtResource("4_jik7v")]
+layout_mode = 2
+metadata/_tab_index = 0
+
+[node name="CodeEditor" parent="PanelContainer/HSplitContainer/TabContainer" instance=ExtResource("3_4uluy")]
 visible = false
 layout_mode = 2
+metadata/_tab_index = 1
 
 [node name="Display" parent="PanelContainer/HSplitContainer" instance=ExtResource("5_gb5yr")]
 unique_name_in_owner = true

--- a/src/ui_parts/code_editor.tscn
+++ b/src/ui_parts/code_editor.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=10 format=3 uid="uid://cr1fdlmbknnko"]
 
-[ext_resource type="Script" path="res://src/ui_parts/code_editor.gd" id="1_nffk0"]
+[ext_resource type="Script" uid="uid://c3q5dvxm6ro1m" path="res://src/ui_parts/code_editor.gd" id="1_nffk0"]
 [ext_resource type="FontFile" uid="uid://dc0w4sx0h0fui" path="res://assets/fonts/FontBold.ttf" id="2_hl52o"]
 [ext_resource type="FontFile" uid="uid://depydd16jq777" path="res://assets/fonts/FontMono.ttf" id="2_p4nol"]
 [ext_resource type="Texture2D" uid="uid://6ymbl3jqersp" path="res://assets/icons/Import.svg" id="4_cuhac"]
 [ext_resource type="Texture2D" uid="uid://dthdjf4v2vlvg" path="res://assets/icons/CodeOptions.svg" id="4_sos04"]
 [ext_resource type="Texture2D" uid="uid://d0uvwj0t44n6v" path="res://assets/icons/Export.svg" id="5_pgurh"]
-[ext_resource type="Script" path="res://src/ui_widgets/BetterTextEdit.gd" id="8_ser4i"]
+[ext_resource type="Script" uid="uid://d1mpyxtnqqxh0" path="res://src/ui_widgets/BetterTextEdit.gd" id="8_ser4i"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_q56qh"]
 content_margin_left = 8.0
@@ -34,7 +34,6 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [node name="CodeEditor" type="VBoxContainer"]
-size_flags_vertical = 3
 theme_override_constants/separation = 0
 script = ExtResource("1_nffk0")
 

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -2,9 +2,9 @@
 
 [ext_resource type="Script" uid="uid://csl2me44lu3yd" path="res://src/ui_parts/inspector.gd" id="1_16ggy"]
 [ext_resource type="PackedScene" uid="uid://bktmk76u7dsu0" path="res://src/ui_parts/root_element_editor.tscn" id="2_jnl50"]
-[ext_resource type="Script" uid="uid://b7nxmncbtpjvt" path="res://src/ui_parts/element_container.gd" id="3_qeptj"]
+[ext_resource type="Script" uid="uid://co24pc68aiwlb" path="res://src/ui_parts/element_container.gd" id="3_qeptj"]
 [ext_resource type="Texture2D" uid="uid://eif2ioi0mw17" path="res://assets/icons/Plus.svg" id="3_vo6hf"]
-[ext_resource type="Script" uid="uid://b04padjc3w1s8" path="res://src/ui_parts/move_to_overlay.gd" id="5_otlmf"]
+[ext_resource type="Script" uid="uid://27atmrvxgbjt" path="res://src/ui_parts/move_to_overlay.gd" id="5_otlmf"]
 
 [node name="Inspector" type="Container"]
 anchors_preset = 15
@@ -13,7 +13,6 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 size_flags_horizontal = 3
-size_flags_vertical = 3
 script = ExtResource("1_16ggy")
 border_width = 2
 corner_radius_top_left = 5


### PR DESCRIPTION
- Closes #3 

This PR implements a tab-based layout where users can switch between the code editor and inspector.