### PR TITLE
Fix UI scaling (for real this time)

### DIFF
--- a/src/portrait_ui/editor_scene.tscn
+++ b/src/portrait_ui/editor_scene.tscn
@@ -18,7 +18,7 @@ theme_override_constants/separation = 0
 script = ExtResource("1_o7lif")
 
 [node name="PanelContainer" type="PanelContainer" parent="."]
-custom_minimum_size = Vector2(360, 0)
+custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
@@ -26,8 +26,7 @@ size_flags_vertical = 3
 [node name="HSplitContainer" type="VSplitContainer" parent="PanelContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
-theme_override_constants/separation = 40
-theme_override_constants/minimum_grab_thickness = 30
+theme_override_constants/separation = 30
 theme_override_styles/split_bar_background = SubResource("StyleBoxFlat_mt61i")
 
 [node name="TabContainer" type="TabContainer" parent="PanelContainer/HSplitContainer"]
@@ -50,3 +49,6 @@ metadata/_tab_index = 1
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_vertical = 3
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2

--- a/src/ui_parts/code_editor.tscn
+++ b/src/ui_parts/code_editor.tscn
@@ -34,6 +34,7 @@ corner_radius_bottom_right = 5
 corner_radius_bottom_left = 5
 
 [node name="CodeEditor" type="VBoxContainer"]
+custom_minimum_size = Vector2(0, 90)
 theme_override_constants/separation = 0
 script = ExtResource("1_nffk0")
 
@@ -99,7 +100,7 @@ size_flags_vertical = 3
 theme_override_constants/separation = -2
 
 [node name="SVGCodeEdit" type="TextEdit" parent="ScriptEditor"]
-custom_minimum_size = Vector2(0, 96)
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3

--- a/src/ui_parts/display.tscn
+++ b/src/ui_parts/display.tscn
@@ -39,7 +39,7 @@ layout_mode = 2
 size_flags_vertical = 3
 
 [node name="ViewportContainer" type="SubViewportContainer" parent="ViewportPanel"]
-custom_minimum_size = Vector2(450, 0)
+custom_minimum_size = Vector2(300, 0)
 layout_mode = 2
 size_flags_vertical = 3
 stretch = true

--- a/src/ui_parts/inspector.tscn
+++ b/src/ui_parts/inspector.tscn
@@ -7,6 +7,7 @@
 [ext_resource type="Script" uid="uid://27atmrvxgbjt" path="res://src/ui_parts/move_to_overlay.gd" id="5_otlmf"]
 
 [node name="Inspector" type="Container"]
+custom_minimum_size = Vector2(0, 90)
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
@@ -34,7 +35,7 @@ theme_override_constants/h_separation = 4
 icon = ExtResource("3_vo6hf")
 
 [node name="ElementContainer" type="Control" parent="."]
-custom_minimum_size = Vector2(0, 240)
+custom_minimum_size = Vector2(0, 80)
 layout_mode = 2
 size_flags_vertical = 3
 script = ExtResource("3_qeptj")


### PR DESCRIPTION
Fixes #5
Previously, the UI was too small, causing difficulty with touch input. Now, it should be optimal across all Android devices.

**Before**

![Screenshot_2025-02-01-14-14-15-390_com.godsvg.mobile.jpg](https://github.com/user-attachments/assets/e0f86886-07b2-4b38-9caa-8d1367343348)

**After**

![Screenshot_2025-02-01-14-13-33-203_com.godsvg.mobile.jpg](https://github.com/user-attachments/assets/c935af2d-12bc-4f87-864e-a7b21f521a8b)

